### PR TITLE
add object type to editorToolbar

### DIFF
--- a/src/VueEditor.vue
+++ b/src/VueEditor.vue
@@ -34,7 +34,7 @@ export default {
     },
     placeholder: String,
     disabled: Boolean,
-    editorToolbar: Array,
+    editorToolbar: [Array, Object],
   },
 
   data() {


### PR DESCRIPTION
toolbar prop can also be something like this:
```js
var quill = new Quill('#editor', {
  modules: {
    toolbar: {
      container: ['bold']
      handlers: {
        'formula': customFormulaHandler
      }
    }
  }
});
```