### PR TITLE
fix quill import for ssr support

### DIFF
--- a/src/VueEditor.vue
+++ b/src/VueEditor.vue
@@ -6,11 +6,16 @@
 </template>
 
 <script>
-import VQuill from 'quill'
+import Vue from 'vue'
 import defaultToolbar from './helpers/toolbar.js'
 import MarkdownShortcuts from './helpers/MarkdownShortcuts'
 import merge from 'lodash.merge'
-const Quill = window.Quill || VQuill
+
+let VQuill;
+if (!Vue.prototype.$isServer) {
+  VQuill = require('quill')
+}
+
 
 export default {
   name: 'vue-editor',
@@ -60,6 +65,7 @@ export default {
   },
 
   mounted() {
+    window.Quill = window.Quill || VQuill
     this.initializeVue2Editor()
     this.handleUpdatedEditor()
   },
@@ -162,7 +168,7 @@ export default {
         var uploader = document.getElementById('file-upload');
         uploader.value = '';
       }
-      
+
       let file = $event.target.files[0]
       let Editor = this.quill
       let range = Editor.getSelection();


### PR DESCRIPTION
In projects with SSR you can see this error:
```
ReferenceError: document is not defined
    at Object.DIFF_DELETE (/home/alexey/projects/yourpet/frontend/node_modules/quill/dist/quill.js:7501:12)
    at __webpack_require__ (/home/alexey/projects/yourpet/frontend/node_modules/quill/dist/quill.js:36:30)
    at Object.defineProperty.value (/home/alexey/projects/yourpet/frontend/node_modules/quill/dist/quill.js:980:1)
    at __webpack_require__ (/home/alexey/projects/yourpet/frontend/node_modules/quill/dist/quill.js:36:30)
    at Object.defineProperty.value (/home/alexey/projects/yourpet/frontend/node_modules/quill/dist/quill.js:4892:14)
    at __webpack_require__ (/home/alexey/projects/yourpet/frontend/node_modules/quill/dist/quill.js:36:30)
    at Object.defineProperty.value (/home/alexey/projects/yourpet/frontend/node_modules/quill/dist/quill.js:9885:13)
    at __webpack_require__ (/home/alexey/projects/yourpet/frontend/node_modules/quill/dist/quill.js:36:30)
    at Object.<anonymous> (/home/alexey/projects/yourpet/frontend/node_modules/quill/dist/quill.js:11397:18)
    at __webpack_require__ (/home/alexey/projects/yourpet/frontend/node_modules/quill/dist/quill.js:36:30)
    at Object.defineProperty.value (/home/alexey/projects/yourpet/frontend/node_modules/quill/dist/quill.js:79:18)
    at /home/alexey/projects/yourpet/frontend/node_modules/quill/dist/quill.js:82:10
    at webpackUniversalModuleDefinition (/home/alexey/projects/yourpet/frontend/node_modules/quill/dist/quill.js:9:20)
    at Object.<anonymous> (/home/alexey/projects/yourpet/frontend/node_modules/quill/dist/quill.js:16:3)
    at Module._compile (module.js:643:30)
    at Object.Module._extensions..js (module.js:654:10)
    at Module.load (module.js:556:32)
    at tryModuleLoad (module.js:499:12)
    at Function.Module._load (module.js:491:3)
    at Module.require (module.js:587:17)
    at require (internal/module.js:11:18)
    at r (/home/alexey/projects/yourpet/frontend/node_modules/vue-server-renderer/build.js:8152:16)
```
You should require Quill only on the client side to support server-side rendering.