### PR TITLE
switch for disable markdownShortcuts

### DIFF
--- a/src/VueEditor.vue
+++ b/src/VueEditor.vue
@@ -26,7 +26,7 @@ export default {
     editorToolbar: Array,
     enableMarkdownShortcuts: {
       type: Boolean,
-      default: true
+      default: false
     },
     editorOptions: {
       type: Object,

--- a/src/VueEditor.vue
+++ b/src/VueEditor.vue
@@ -24,6 +24,10 @@ export default {
     disabled: Boolean,
     customModules: Array,
     editorToolbar: Array,
+    enableMarkdownShortcuts: {
+      type: Boolean,
+      default: true
+    },
     editorOptions: {
       type: Object,
       default: function () {
@@ -113,7 +117,9 @@ export default {
     },
 
     registerBuiltInModules() {
-      Quill.register('modules/markdownShortcuts', MarkdownShortcuts, true)
+      if (this.enableMarkdownShortcuts) {
+        Quill.register('modules/markdownShortcuts', MarkdownShortcuts, true)
+      }
     },
 
     registerCustomModules() {


### PR DESCRIPTION
There is disappering some ```#```-starting source codes, when I'm editing [source code](https://nkonev.name/post/46)
for example 
```
# ps -eouser,uid,pid,ppid,pcpu,pmem,cmd --sort=-pcpu
USER      UID  PID PPID %CPU %MEM CMD
apache     48 1344  923 0.5 1.4 /usr/sbin/httpd -DFOREGROUND
```

I want to able to disable markdown plugin.