### PR TITLE
Allow editorToolbar as an Object

### DIFF
--- a/src/VueEditor.vue
+++ b/src/VueEditor.vue
@@ -34,7 +34,7 @@ export default {
     disabled: {
       type: Boolean
     },
-    editorToolbar: Array,
+    editorToolbar: [Array, Object],
     editorOptions: {
       type: Object,
       required: false,


### PR DESCRIPTION
I wanted to pass some handlers to the `editorToolbar` config, and noted that it's currently possible to pass an object, given **vue2-editor** just passes it straight to **quilljs** as `toolbar`, which does allow an object: https://quilljs.com/docs/modules/toolbar/

However **vue2-editor** currently complains about the prop type, so this PR fixes that. Thanks!