### PR TITLE
docs: fix Saving The Content Example

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -123,7 +123,7 @@ export default {
 
 ## Saving The Content
 
-<<< @/docs/.vuepress/code-examples/source/custom-toolbar.vue
+<<< @/docs/.vuepress/code-examples/source/save-content.vue
 
 <hr class="spacer" style="margin: 1em 0 1.75em !important; opacity: 0;"/>
 


### PR DESCRIPTION
`Saving The Content` example code is showing `Custom Toolbar` example code.
https://www.vue2editor.com/examples/#saving-the-content