### PR TITLE
Suppress Quill warnings from custom modules

### DIFF
--- a/src/helpers/old-api.js
+++ b/src/helpers/old-api.js
@@ -6,7 +6,7 @@ export default {
     registerCustomModules(Quill) {
       if (this.customModules !== undefined) {
         this.customModules.forEach(customModule => {
-          Quill.register("modules/" + customModule.alias, customModule.module);
+          Quill.register("modules/" + customModule.alias, customModule.module, true);
         });
       }
     }


### PR DESCRIPTION
Suppress warnings when using custom modules.
Warning error example using `quill-mention` passing it as `customModules` editor prop:
![image](https://user-images.githubusercontent.com/31900327/151832916-cc83f580-a78d-4cb2-900b-e45801baa7a1.png)
