### PR TITLE
fix: supports undo command when it has only initial content

### DIFF
--- a/src/components/VueEditor.vue
+++ b/src/components/VueEditor.vue
@@ -87,9 +87,9 @@ export default {
 
   methods: {
     initializeEditor() {
+      this.handleInitialContent();
       this.setupQuillEditor();
       this.checkForCustomImageHandler();
-      this.handleInitialContent();
       this.registerEditorEventListeners();
       this.$emit("ready", this.quill);
     },
@@ -159,7 +159,7 @@ export default {
     },
 
     handleInitialContent() {
-      if (this.value) this.quill.root.innerHTML = this.value; // Set initial editor content
+      if (this.value) this.$refs.quillContainer.innerHTML = this.value; // Set initial editor content
     },
 
     handleSelectionChange(range, oldRange) {


### PR DESCRIPTION
When the editor has an initial value and the undo command is pressed (ctrl+z or cmd+z) the entire content is erased.

This problem occurs because it is changing the content after it is loaded.
The correct form of using the initial content is putting the content inside the quill container, in HTML.
As can be seen here: https://quilljs.com/docs/quickstart/

This code simulates this behavior, changing the `innerHTML` from the container before Quill is mounted and it fixes the problem